### PR TITLE
Version 0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 0.0.1 - 2021-10-19
 
 ### Added
+- A rule to rename the breseq `.gd` and `.vcf` output based on sample name
 
 ### Changed
+- Updated `workflow/envs/multiqc_config.yaml` to better handle sample names
+  across modules
 
 ### Bug fixes
+- Fixed a bug in the `quality_control` rule where input samples could not be
+  found

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ your error.
 
 # Version history
 
-Currently at version 0.0.0
+Currently at version 0.0.1
 
 See the [Changelog](CHANGELOG.md) for version history and upcoming
 features.

--- a/Snakefile
+++ b/Snakefile
@@ -1,4 +1,4 @@
-# control of the pipeline
+#control of the pipeline
 configfile: "config/config.yaml"
 # sample metadata and information
 pepfile: "pep/config.yaml"
@@ -67,7 +67,6 @@ include: "workflow/rules/preprocessing.smk"
 include: "workflow/rules/quality_control.smk"
 include: "workflow/rules/variant_calling.smk"
 include: "workflow/rules/test.smk"
-
 
 
 ## overall rules

--- a/workflow/envs/multiqc_config.yaml
+++ b/workflow/envs/multiqc_config.yaml
@@ -18,3 +18,31 @@ module_order:
 report_section_order:
     fastq_trimmed:
         before: fastqc_raw
+
+extra_fn_clean_exts:
+    - type: remove
+      pattern: "trim_paired_"
+    - type: "truncate"
+      pattern: "R1"
+      module:
+          - trimmomatic
+          - cutadapt
+    - type: "truncate"
+      pattern: "R2"
+      module:
+          - trimmomatic
+          - cutadapt
+    - type: "truncate"
+      pattern: "cutadapt"
+      module:
+          - cutadapt
+    - type: "truncate"
+      pattern: "_cut"
+      module:
+          - trimmomatic
+
+use_filename_as_sample_name:
+    - fastqc
+    - cutadapt
+
+plots_flat_numseries: 250

--- a/workflow/rules/quality_control.smk
+++ b/workflow/rules/quality_control.smk
@@ -29,7 +29,7 @@ rule read_qc:
         touch("results/quality_control/read_qc.done")
 
 def match_fastq_to_sample(sample, pair, pep):
-    out = lookup_sample_metadata(sample, "file_path", pep)
+    out = lookup_sample_metadata(sample, "infile_path", pep)
     if pair == "R1":
         out += lookup_sample_metadata(sample, "filenameR1", pep)
     elif pair == "R2":

--- a/workflow/rules/variant_calling.smk
+++ b/workflow/rules/variant_calling.smk
@@ -37,3 +37,23 @@ rule breseq:
         "-n {wildcards.sample} "
         "-o results/variant_calling/breseq/{wildcards.sample} "
         "-j {threads} > {log.stdout} 2> {log.stderr}"
+
+rule clean_rename:
+    shell:
+        "rm -fr results/variant_calling/breseq/renamed_output"
+
+rule run_rename:
+    input:
+        expand("results/variant_calling/breseq/renamed_output/{sample}.vcf", sample = samples(pep))
+
+rule rename_breseq_output:
+    input:
+        vcf="results/variant_calling/breseq/{sample}/output/output.vcf",
+        gd="results/variant_calling/breseq/{sample}/output/output.gd"
+    output:
+        outvcf="results/variant_calling/breseq/renamed_output/{sample}.vcf",
+        outgd="results/variant_calling/breseq/renamed_output/{sample}.gd"
+
+    threads: 1
+    shell:
+        "cp {input.vcf} {output.outvcf} && cp {input.gd} {output.outgd}"


### PR DESCRIPTION
## 0.0.1 - 2021-10-19

### Added
- A rule to rename the breseq `.gd` and `.vcf` output based on sample name. Resolves #2, resolves #3 

### Changed
- Updated `workflow/envs/multiqc_config.yaml` to better handle sample names
  across modules. 

### Bug fixes
- Fixed a bug in the `quality_control` rule where input samples could not be
  found. Closes #1 