### PR TITLE
Update testing, give tsv-based output, update to modern snakemake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.0.3 - 2024-05-16
+
+### Added
+- `.tsv` based summaries of `breseq` output
+- example `htcondor`-based running profile for `snakemake`>= 8.0
+
+### Changed
+- test module now creates data where `breseq` can detect deletions
+
 ## 0.0.2 - 2024-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Develop
+## 0.0.2 - 2024-05-08
 
 ### Added
 - De novo assembly with unicycler

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Snakemake](https://img.shields.io/badge/snakemake-≥5.24.2-brightgreen.svg)](https://snakemake.bitbucket.io) [![PEP compatible](http://pepkit.github.io/img/PEP-compatible-green.svg)](http://pepkit.github.io)
+[![Snakemake](https://img.shields.io/badge/snakemake-≥8.0-brightgreen.svg)](https://snakemake.bitbucket.io) [![PEP compatible](http://pepkit.github.io/img/PEP-compatible-green.svg)](http://pepkit.github.io)
 # Pipeline for processing bacterial re-sequencing data
 
 The goal of this project is to create a reproducible analysis pipeline
@@ -39,7 +39,7 @@ Once `miniconda` is installed, both `snakemake` and `peppy` can be
 installed in their own environment easily using: 
 
 ``` 
-conda create -n Bacterial_reseq snakemake>=5.24.2 peppy 
+conda create -n Bacterial_reseq snakemake>=8 peppy 
 conda activate Bacterial_reseq
 ```
 
@@ -81,7 +81,7 @@ your environment as well.  For example, if you are using an
 like so: 
 
 ``` 
-conda create -n Bacterial_reseq snakemake>=5.24.2 peppy htcondor>=8.9.5 
+conda create -n Bacterial_reseq snakemake>=8.0 peppy htcondor>=8.9.5 snakemake-executor-plugin-cluster-generic
 conda activate Bacterial_reseq 
 ```
 
@@ -89,10 +89,22 @@ And then run the pipeline using the job management software
 with an environment-specific
 [profile](https://snakemake.readthedocs.io/en/v5.1.4/executable.html#profiles).
 
-For example: 
+For running with `htcondor` I have included an example profile in
+`htcondor_profile/`. 
+
+To get this setup do the following:
+- Create the directory `~/.config/snakemake/htcondor`
+- Copy the files in `htcondor_profile` over to
+  `~/.config/snakemake/htcondor`
+- Create the directory `~/.condor_jobs`
+
+Then you should be able to run the pipeline with `snakemake` version
+>8.0 and automatic submission of jobs through `htcondor` using:
+
 ``` 
 snakemake --use-conda --cores 10 --profile htcondor
 ```
+
 
 ## If installing on an ARM-based Mac (i.e. 2020 M1 Chips and beyond)
 

--- a/README.md
+++ b/README.md
@@ -90,17 +90,18 @@ with an environment-specific
 [profile](https://snakemake.readthedocs.io/en/v5.1.4/executable.html#profiles).
 
 For running with `htcondor` I have included an example profile in
-`htcondor_profile/`. This is based on the work-in-progress v8.0
-profile [here](https://github.com/Snakemake-Profiles/htcondor).
+[htcondor_profile/](htcondor_profile/). This is based on the
+work-in-progress v8.0 profile
+[here](https://github.com/Snakemake-Profiles/htcondor).
 
 To get this setup do the following:
 - Create the directory `~/.config/snakemake/htcondor`
-- Copy the files in `htcondor_profile` over to
+- Copy the files in [htcondor_profile/](htcondor_profile/) over to
   `~/.config/snakemake/htcondor`
 - Create the directory `~/.condor_jobs`
 
 Then you should be able to run the pipeline with `snakemake` version
->8.0 and automatic submission of jobs through `htcondor` using:
+8.0 and automatic submission of jobs through `htcondor` using:
 
 ``` 
 snakemake --use-conda --cores 10 --profile htcondor
@@ -240,7 +241,7 @@ your error.
 
 # Version history
 
-Currently at version 0.0.2
+Currently at version 0.0.3
 
 See the [Changelog](CHANGELOG.md) for version history and upcoming
 features.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ with an environment-specific
 [profile](https://snakemake.readthedocs.io/en/v5.1.4/executable.html#profiles).
 
 For running with `htcondor` I have included an example profile in
-`htcondor_profile/`. 
+`htcondor_profile/`. This is based on the work-in-progress v8.0
+profile [here](https://github.com/Snakemake-Profiles/htcondor).
 
 To get this setup do the following:
 - Create the directory `~/.config/snakemake/htcondor`

--- a/Snakefile
+++ b/Snakefile
@@ -75,7 +75,7 @@ include: "workflow/rules/assembly.smk"
 
 rule run_variant_calling:
     input: 
-        expand("results/variant_calling/breseq/{sample}/output/summary.html", \
+        expand("results/variant_calling/breseq/renamed_output/{sample}.tsv", \
         sample = samples(pep))
 
 rule run_all:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,5 +5,9 @@ preprocessing:
         trimmomatic_pe:
             trim_param_string:
                 value: "LEADING:3 TRAILING:3 SLIDINGWINDOW:4:15"
+variant_calling:
+    breseq:
+        breseq_param_string:
+            value: " "
 
 

--- a/htcondor_profile/config.yaml
+++ b/htcondor_profile/config.yaml
@@ -1,0 +1,10 @@
+jobscript: "grid-jobscript.sh"
+executor: "cluster-generic"
+cluster-generic-status-cmd: "grid-status.py"
+cluster-generic-submit-cmd: "grid-submit.py"
+max-jobs-per-second: 100
+max-status-checks-per-second: 100
+restart-times: 5
+local-cores: 10
+jobs: 5000
+verbose: false

--- a/htcondor_profile/grid-jobscript.sh
+++ b/htcondor_profile/grid-jobscript.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# properties = {properties}
+
+set -e
+
+echo "hostname:"
+hostname -f
+
+{exec_job}

--- a/htcondor_profile/grid-status.py
+++ b/htcondor_profile/grid-status.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import sys
+import htcondor
+from htcondor import JobEventType
+from os.path import join
+
+
+def print_and_exit(s):
+    print(s)
+    exit()
+
+
+jobID, UUID, clusterID = sys.argv[1].split("_")
+
+jobDir = "~/.condor_jobs/{}_{}".format(jobID, UUID)
+jobLog = join(jobDir, "condor.log")
+
+failed_states = [
+    JobEventType.JOB_HELD,
+    JobEventType.JOB_ABORTED,
+    JobEventType.EXECUTABLE_ERROR,
+]
+
+try:
+    jel = htcondor.JobEventLog(join(jobLog))
+    for event in jel.events(stop_after=5):
+        if event.type in failed_states:
+            print_and_exit("failed")
+        if event.type is JobEventType.JOB_TERMINATED:
+            if event["ReturnValue"] == 0:
+                print_and_exit("success")
+            print_and_exit("failed")
+except OSError as e:
+    print_and_exit("failed: {}".format(e))
+
+print_and_exit("running")

--- a/htcondor_profile/grid-submit.py
+++ b/htcondor_profile/grid-submit.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import sys
+import htcondor
+from os import makedirs
+from os.path import join
+from uuid import uuid4
+
+from snakemake.utils import read_job_properties
+
+
+jobscript = sys.argv[1]
+job_properties = read_job_properties(jobscript)
+
+UUID = uuid4()  # random UUID
+jobDir = "~/.condor_jobs/{}_{}".format(job_properties["jobid"], UUID)
+makedirs(jobDir, exist_ok=True)
+
+sub = htcondor.Submit(
+    {
+        "executable": "/bin/bash",
+        "arguments": jobscript,
+        "max_retries": "5",
+        "log": join(jobDir, "condor.log"),
+        "output": join(jobDir, "condor.out"),
+        "error": join(jobDir, "condor.err"),
+        "getenv": "True",
+        "request_cpus": str(job_properties["threads"]),
+    }
+)
+
+request_memory = job_properties["resources"].get("mem_mb", None)
+if request_memory is not None:
+    sub["request_memory"] = str(request_memory)
+
+request_disk = job_properties["resources"].get("disk_mb", None)
+if request_disk is not None:
+    sub["request_disk"] = str(request_disk)
+
+schedd = htcondor.Schedd()
+clusterID = schedd.submit(sub)
+
+# print jobid for use in Snakemake
+print("{}_{}_{}".format(job_properties["jobid"], UUID, clusterID))

--- a/workflow/envs/variant_calling.yaml
+++ b/workflow/envs/variant_calling.yaml
@@ -2,6 +2,6 @@ channels:
     - conda-forge
     - bioconda
 dependencies:
-    - breseq=0.35.5
-    - tbb=2020.2
-    - bowtie2=2.4.2
+    - breseq>=0.38.0
+    - tbb>=2020.2
+    - bowtie2>=2.4.2

--- a/workflow/rules/test.smk
+++ b/workflow/rules/test.smk
@@ -41,6 +41,7 @@ rule combine_fastas_test:
          "results/test/combine_fasta/{wildcards.sample} "
          "{input.input_files} "
          "--masked_regions {input.mask_regions} "
+         "--masked_delete "
          "> {log.stdout} 2> {log.stderr}"
 
 

--- a/workflow/scripts/combine_fasta.py
+++ b/workflow/scripts/combine_fasta.py
@@ -10,6 +10,7 @@ if __name__ == "__main__":
     parser.add_argument('infiles', type=str, nargs='+', help="files to combine")
     parser.add_argument('--masked_regions', type=str,
             help="A .bed file containing a list of regions to replace with Ns")
+    parser.add_argument('--masked_delete', action = "store_true", help = "delete masked regions?")
     
     args = parser.parse_args()
     genome_name = args.outfilepre
@@ -37,6 +38,8 @@ if __name__ == "__main__":
             total_region_length = entry["end"] - entry["start"]
             this_chrm = final_fasta.pull_entry(entry["chrm"])
             this_chrm.mutate(entry["start"], entry["end"], "N"*total_region_length)
+        if args.masked_delete:
+            this_chrm.delete_Ns()
 
     # Figure out total size of each chromosome
     with open(genome_name + "_contig_sizes.tsv", mode = "w") as outf:

--- a/workflow/scripts/fasta.py
+++ b/workflow/scripts/fasta.py
@@ -93,7 +93,15 @@ class FastaEntry(object):
         total_size = len(self.seq)
         self.seq = self.seq[0:start] + new_seq + self.seq[end:total_size]
 
+    def delete_Ns(self):
+        """
+        Delete any Ns in the sequence shortening it as a result
 
+        Returns:
+            Nothing. self.seq is altered in place
+        """
+
+        self.seq = self.seq.replace("N", "")
 
     def __len__(self):
         if self.length:


### PR DESCRIPTION
## 0.0.3 - 2024-05-16

### Added
- `.tsv` based summaries of `breseq` output
- example `htcondor`-based running profile for `snakemake`>= 8.0

### Changed
- test module now creates data where `breseq` can detect deletions